### PR TITLE
Handle conflicts on insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Insert data from a file into a table.
 `-t`, `--table TEXT`
 - Name of the table to insert into. Required.
 
+`-oc`, `--on-conflict TEXT`
+- How to handle insert conflicts. [nothing|update]
+
 #### Examples
 
 ```bash

--- a/heave/cli.py
+++ b/heave/cli.py
@@ -105,12 +105,18 @@ def cli(
 @click.argument("path", type=click.Path(exists=True))
 @click.option("-t", "--table", required=True, help="Table to insert into.")
 @click.option("-s", "--schema", help="Table schema name.")
+@click.option(
+    "-oc",
+    "--on-conflict",
+    type=click.Choice(["nothing", "update"], case_sensitive=False),
+    help="Handle conflict errors.",
+)
 @click.pass_obj
-def insert(obj, path: str, table: str, schema: str | None):
+def insert(obj, path: str, table: str, schema: str | None, on_conflict: str | None):
     """Insert data from a file into a table."""
     data = file.read_csv(path)
     sql_table = sql.reflect_table(obj, table, schema)
-    sql.insert(obj, sql_table, data)
+    sql.insert(obj, sql_table, data, on_conflict=on_conflict)
     click.echo(f"Inserted rows into {sql_table.name}.")
 
 

--- a/heave/sql.py
+++ b/heave/sql.py
@@ -1,8 +1,15 @@
 """Batch SQL operations."""
 from sqlalchemy import Connection, MetaData
 from sqlalchemy import Table as SqlTable
+from sqlalchemy.exc import IntegrityError
 
 from heave import Table
+
+
+class InvalidDb(Exception):
+    """Invalid Database Exception."""
+
+    pass
 
 
 def reflect_table(
@@ -13,10 +20,53 @@ def reflect_table(
     return SqlTable(table_name, metadata, autoload_with=connection, schema=schema)
 
 
-def insert(connection: Connection, sql_table: SqlTable, data: Table) -> None:
+def update_from_conflict(
+    table: SqlTable,
+    conflict: IntegrityError,
+    header: tuple[str, ...],
+    row: tuple[str, ...],
+):
+    """Write an update statement from a conflict."""
+    constraint = next(
+        c for c in table.constraints if c.name == conflict.orig.diag.constraint_name
+    )
+    id_map = {c.name: header.index(c.name) for c in constraint.c}
+    val_map = {c: idx for idx, c in enumerate(header) if c not in id_map.keys()}
+    update_stmt = (
+        table.update()
+        .where(*(getattr(table.c, c) == row[i] for c, i in id_map.items()))
+        .values({c: row[i] for c, i in val_map.items()})
+    )
+    return update_stmt
+
+
+def insert(
+    connection: Connection,
+    sql_table: SqlTable,
+    data: Table,
+    on_conflict: str | None = None,
+) -> None:
     """Insert data into a table."""
     for row in data.rows:
-        connection.execute(sql_table.insert().values(dict(zip(data.header, row))))
+        trans = connection.begin_nested()
+        stmt = sql_table.insert().values(dict(zip(data.header, row)))
+        try:
+            connection.execute(stmt)
+            trans.commit()
+        except IntegrityError as exc:
+            trans.rollback()
+            if on_conflict == "nothing":
+                continue
+            if on_conflict == "update":
+                # cannot write an update if the error does not have diagnostic info
+                if not hasattr(exc.orig, "diag"):
+                    raise InvalidDb(
+                        "Database does not support UPDATE ON CONFLICT."
+                    ) from None
+                update_stmt = update_from_conflict(sql_table, exc, data.header, row)
+                connection.execute(update_stmt)
+                continue
+            raise exc from exc
 
 
 def read(connection: Connection, sql_table: SqlTable) -> Table:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,6 +140,26 @@ class TestCli:
         for row in table.rows:
             assert row[1] != "jane.doe"
 
+    def test_insert_conflict(self, runner, monkeypatch):
+        """Test that on-conflict option is passed to insert function."""
+        mock_insert = Mock()
+        monkeypatch.setattr("heave.sql.insert", mock_insert)
+        result = runner.invoke(
+            cli,
+            ["insert", "--table", "user", "--on-conflict", "nothing", self.test_file],
+        )
+        assert result.exit_code == 0
+        mock_insert.assert_called()
+        assert mock_insert.call_args.kwargs["on_conflict"] == "nothing"
+
+    def test_insert_conflict_invalid(self, runner):
+        """Test that the on-conflict option only accepts valid choices."""
+        result = runner.invoke(
+            cli, ["insert", "--table", "user", "--on-conflict", "foo", self.test_file]
+        )
+        assert result.exit_code == 2
+        assert "Error: Invalid value for '--on-conflict': 'foo' is not one of 'nothing', 'update'."
+
     def test_read(self, runner, monkeypatch):
         """Test the read command."""
         mock_write_csv = Mock()

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,7 +1,12 @@
 """Tests for the sql module."""
+from unittest.mock import Mock
+
+import pytest
 from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 
 from heave import Table, sql
+from heave.sql import InvalidDb, update_from_conflict
 
 
 class TestSql:
@@ -29,6 +34,66 @@ class TestSql:
             text("SELECT * FROM user WHERE username = 'jane.doe';")
         )
         assert result.fetchone() is not None
+
+    def test_insert_conflict_nothing(self, connection):
+        """Test that insert handles skips conflicts."""
+        data = Table(
+            [
+                ("username", "email", "password"),
+                ("jane.doe", "janedoe@example.com", "yourSecurePassword"),
+                ("john.doe", "johndoe@example.com", "yourSecurePassword"),
+            ]
+        )
+        sql_table = sql.reflect_table(connection, "user")
+        sql.insert(connection, sql_table, data, on_conflict="nothing")
+        result = connection.execute(
+            text("SELECT password FROM user WHERE username = 'john.doe';")
+        )
+        assert result.scalar() == "yourSecurePassword"
+        result = connection.execute(
+            text("SELECT * FROM user WHERE username = 'jane.doe';")
+        )
+        assert result.fetchone() is not None
+
+    def test_insert_conflict_update_invalid_db(self, connection):
+        """Test that insert raises an Invalid DB error when called with update on conflict."""
+        data = Table(
+            [
+                ("username", "email", "password"),
+                ("john.doe", "johndoe@example.com", "yourSecurePassword"),
+            ]
+        )
+        sql_table = sql.reflect_table(connection, "user")
+
+        with pytest.raises(InvalidDb):
+            sql.insert(connection, sql_table, data, on_conflict="update")
+
+    def test_update_from_conflict(self, connection, monkeypatch):
+        """Test that update_from_conflict writes the correct SQL."""
+        mock_orig = Mock()
+        mock_orig.diag.constraint_name = "uq_username"
+        mock_integrity_error = IntegrityError("", {}, orig=mock_orig)
+        data = Table(
+            [
+                ("username", "email", "password"),
+                ("john.doe", "johndoe@example.com", "yourSecurePassword"),
+            ]
+        )
+        sql_table = sql.reflect_table(connection, "user")
+        uq_constraint = next(
+            cns
+            for cns in sql_table.constraints
+            if "username" in [col.name for col in cns.columns]
+        )
+        uq_constraint.name = mock_orig.diag.constraint_name
+        sql_table.constraints = [uq_constraint]
+        stmt = update_from_conflict(
+            sql_table, mock_integrity_error, data.header, next(data.rows)
+        )
+        assert (
+            str(stmt)
+            == 'UPDATE "user" SET email=:email, password=:password WHERE "user".username = :username_1'
+        )
 
     def test_read(self, connection):
         """Test the read function."""


### PR DESCRIPTION
Allow users to specify how `insert` conflicts should be handled.
Either by doing `nothing` or by writing an `update`.