### PR TITLE
fix(cli): don't create db connection if help

### DIFF
--- a/heave/cli.py
+++ b/heave/cli.py
@@ -1,4 +1,5 @@
 """Heave CLI."""
+import sys
 from pathlib import Path
 
 import click
@@ -98,7 +99,8 @@ def cli(
     # default to postgres connection parameters
     dialect = "postgresql"
     driver = "psycopg"
-    connect(ctx, dialect, dbname, host, str(port), username, driver)
+    if "--help" not in sys.argv:
+        connect(ctx, dialect, dbname, host, str(port), username, driver)
 
 
 @cli.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,10 +68,13 @@ class TestCli:
         yield
         os.remove(self.test_file)
 
-    def test_help(self, runner):
+    def test_help(self, runner, monkeypatch):
         """Test the help flag."""
+        mock_connect = Mock()
+        monkeypatch.setattr("heave.cli.connect", mock_connect)
         result = runner.invoke(cli, ["--help"])
         assert result.exit_code == 0
+        assert mock_connect.called is False
         assert "Show this message and exit." in result.output
 
     def test_connection(self, runner, monkeypatch):


### PR DESCRIPTION
Don't create a db connection if the help option is passed. This way connection parameters aren't required to see the help message for subcommands.

Closes #17
